### PR TITLE
fix: VOICEVOX接続エラー表示の改善 (issue #11)

### DIFF
--- a/src/scripts/ui.js
+++ b/src/scripts/ui.js
@@ -192,7 +192,10 @@ async function initVoicevoxTsumugi() {
       }
       speakerId = null;
       const reason = error instanceof Error ? error.message : "unknown";
-      setVoiceState(`VOICEVOX未接続 (${VOICEVOX_URL}, ${reason})`);
+      const hint = window.location.protocol === "https:" && !explicitVoiceApi
+        ? " — ⚙ を押してプロキシURLを再確認してください"
+        : "";
+      setVoiceState(`VOICEVOX未接続 (${VOICEVOX_URL}, ${reason})${hint}`);
       return false;
     }
   }
@@ -450,9 +453,13 @@ voiceTestBtn.addEventListener("click", async () => {
 voiceSettingsBtn.addEventListener("click", () => {
   const saved = localStorage.getItem("voiceApi") || "";
   voiceApiInput.value = VOICEVOX_URL !== "/voicevox" ? VOICEVOX_URL : saved;
-  dialogCurrentUrl.textContent = VOICEVOX_URL !== "/voicevox"
-    ? `現在: ${VOICEVOX_URL}`
-    : "現在: ローカル（/voicevox）";
+  if (VOICEVOX_URL !== "/voicevox") {
+    dialogCurrentUrl.textContent = `現在: ${VOICEVOX_URL}`;
+  } else if (window.location.protocol === "https:") {
+    dialogCurrentUrl.textContent = "現在: 未設定（HTTPS 環境ではプロキシ URL の入力が必要です）";
+  } else {
+    dialogCurrentUrl.textContent = "現在: ローカル（/voicevox）";
+  }
   voiceSettingsDialog.showModal();
 });
 


### PR DESCRIPTION
## 原因調査

Issue #11 「接続試行はできるけど接続できない」の調査結果：

### 根本原因

複数の要因が絡んでいます：

1. **設定ダイアログの `現在の URL` 表示が誤解を招く**  
   HTTPS環境でプロキシ未設定の場合、ダイアログに「現在: ローカル（/voicevox）」と表示されていた。  
   GitHub Pagesなど HTTPS 環境では `/voicevox` は同一オリジンに存在しないため、「ローカル」という表記がユーザーを混乱させていた。

2. **接続リトライ失敗時のヒントが不足**  
   プロキシURLを設定して接続試行を3回リトライ後に失敗した際、「VOICEVOX未接続 (URL, reason)」のみ表示され、次のアクションが不明瞭だった。

### 変更内容 (`src/scripts/ui.js`)

- ⚙設定ダイアログを開いた際の「現在のURL」表示を3パターンに分岐：
  - プロキシURL設定済み → `現在: <URL>`
  - HTTPS かつ未設定 → `現在: 未設定（HTTPS 環境ではプロキシ URL の入力が必要です）`
  - HTTP ローカル → `現在: ローカル（/voicevox）`
- リトライ全失敗時、HTTPS かつ `explicitVoiceApi` 未指定の場合にヒントを追加

### 備考

`render.yaml` の `VOICEVOX_ENGINE_URL` がプレースホルダー値のままの場合、プロキシ自体は起動するが VOICEVOX エンジンへの接続は502エラーになります。Render ダッシュボードで実際のエンジン URL を設定してください。

## Test plan

- [ ] GitHub Pages (HTTPS) 環境で ⚙ を押したとき「現在: 未設定（HTTPS 環境では...）」と表示されることを確認
- [ ] ローカル (HTTP) 環境で ⚙ を押したとき「現在: ローカル（/voicevox）」と表示されることを確認
- [ ] プロキシURLを設定して接続試行が全て失敗したとき、「⚙ を押してプロキシURLを再確認してください」のヒントが表示されることを確認
- [ ] プロキシURL設定済み環境で正常に接続できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)