### PR TITLE
feat: スロットゲーム v2 - 本格パチスロUI/エンジン刷新

### DIFF
--- a/src-v2/audio.js
+++ b/src-v2/audio.js
@@ -1,0 +1,253 @@
+/**
+ * audio.js - V2 Pachislot Audio Engine
+ * Web Audio API sound effects for the pachislot game
+ */
+
+'use strict';
+
+class PachislotAudio {
+  constructor() {
+    this.ctx = null;
+    this.masterGain = null;
+    this.enabled = true;
+    this._initOnGesture = this._initOnGesture.bind(this);
+  }
+
+  // Initialize AudioContext on first user gesture
+  init() {
+    if (this.ctx) return;
+    try {
+      this.ctx = new (window.AudioContext || window.webkitAudioContext)();
+      this.masterGain = this.ctx.createGain();
+      this.masterGain.gain.value = 0.7;
+      this.masterGain.connect(this.ctx.destination);
+    } catch (e) {
+      this.enabled = false;
+    }
+  }
+
+  _initOnGesture() {
+    this.init();
+    if (this.ctx && this.ctx.state === 'suspended') {
+      this.ctx.resume().catch(() => {});
+    }
+  }
+
+  _ensureRunning() {
+    if (!this.ctx) this.init();
+    if (this.ctx && this.ctx.state === 'suspended') {
+      this.ctx.resume().catch(() => {});
+    }
+  }
+
+  _now() {
+    return this.ctx ? this.ctx.currentTime : 0;
+  }
+
+  // Create oscillator helper
+  _osc(type, freq, startTime, duration, gainPeak, freqEnd) {
+    if (!this.ctx || !this.enabled) return;
+    const osc = this.ctx.createOscillator();
+    const gain = this.ctx.createGain();
+    osc.type = type;
+    osc.frequency.setValueAtTime(freq, startTime);
+    if (freqEnd !== undefined) {
+      osc.frequency.exponentialRampToValueAtTime(freqEnd, startTime + duration);
+    }
+    gain.gain.setValueAtTime(0.0001, startTime);
+    gain.gain.exponentialRampToValueAtTime(gainPeak, startTime + 0.01);
+    gain.gain.exponentialRampToValueAtTime(0.0001, startTime + duration);
+    osc.connect(gain);
+    gain.connect(this.masterGain);
+    osc.start(startTime);
+    osc.stop(startTime + duration + 0.02);
+  }
+
+  // Coin insert sound
+  playCoinInsert() {
+    this._ensureRunning();
+    if (!this.ctx) return;
+    const t = this._now();
+    this._osc('sine', 880, t, 0.08, 0.15, 1100);
+    this._osc('sine', 1100, t + 0.06, 0.08, 0.12, 880);
+  }
+
+  // Lever/spin start sound
+  playSpinStart() {
+    this._ensureRunning();
+    if (!this.ctx) return;
+    const t = this._now();
+    // Mechanical click + whirr
+    this._osc('sawtooth', 200, t, 0.05, 0.2, 80);
+    this._osc('triangle', 400, t + 0.02, 0.15, 0.15, 200);
+    // Add reel noise
+    const bufferSize = this.ctx.sampleRate * 0.1;
+    const buffer = this.ctx.createBuffer(1, bufferSize, this.ctx.sampleRate);
+    const data = buffer.getChannelData(0);
+    for (let i = 0; i < bufferSize; i++) {
+      data[i] = (Math.random() * 2 - 1) * 0.1;
+    }
+    const noise = this.ctx.createBufferSource();
+    noise.buffer = buffer;
+    const noiseGain = this.ctx.createGain();
+    noiseGain.gain.setValueAtTime(0.3, t);
+    noiseGain.gain.exponentialRampToValueAtTime(0.0001, t + 0.1);
+    noise.connect(noiseGain);
+    noiseGain.connect(this.masterGain);
+    noise.start(t);
+  }
+
+  // Reel stop sound (mechanical thud)
+  playReelStop(reelIndex) {
+    this._ensureRunning();
+    if (!this.ctx) return;
+    const t = this._now();
+    const baseFreq = 110 - reelIndex * 10;
+    this._osc('triangle', baseFreq * 2, t, 0.12, 0.3, baseFreq);
+    // Click
+    this._osc('square', 800, t, 0.03, 0.2, 400);
+  }
+
+  // Small win sound
+  playSmallWin() {
+    this._ensureRunning();
+    if (!this.ctx) return;
+    const t = this._now();
+    const notes = [523.25, 659.25, 783.99];
+    notes.forEach((freq, i) => {
+      this._osc('sine', freq, t + i * 0.08, 0.15, 0.25);
+    });
+  }
+
+  // Win sound (ascending arpeggio)
+  playWin() {
+    this._ensureRunning();
+    if (!this.ctx) return;
+    const t = this._now();
+    const notes = [261.63, 329.63, 392.00, 523.25, 659.25];
+    notes.forEach((freq, i) => {
+      this._osc('square', freq, t + i * 0.07, 0.18, 0.2);
+      this._osc('sine', freq * 2, t + i * 0.07 + 0.01, 0.16, 0.1);
+    });
+  }
+
+  // Big win sound (fanfare)
+  playBigWin() {
+    this._ensureRunning();
+    if (!this.ctx) return;
+    const t = this._now();
+    // Fanfare notes
+    const melody = [392, 523.25, 659.25, 783.99, 1046.50];
+    melody.forEach((freq, i) => {
+      this._osc('square', freq, t + i * 0.1, 0.22, 0.25);
+      this._osc('triangle', freq * 0.5, t + i * 0.1, 0.22, 0.15);
+    });
+    // Sustain chord
+    [523.25, 659.25, 783.99].forEach(freq => {
+      this._osc('sine', freq, t + 0.55, 0.4, 0.12);
+    });
+  }
+
+  // Jackpot sound (full fanfare + explosion)
+  playJackpot() {
+    this._ensureRunning();
+    if (!this.ctx) return;
+    const t = this._now();
+    // Ascending sweep
+    const melody = [261.63, 329.63, 392, 523.25, 659.25, 783.99, 1046.5, 1318.5];
+    melody.forEach((freq, i) => {
+      this._osc('square', freq, t + i * 0.07, 0.2, 0.3);
+      this._osc('sawtooth', freq, t + i * 0.07, 0.2, 0.1);
+    });
+    // Victory chord
+    [523.25, 659.25, 783.99, 1046.5].forEach((freq, i) => {
+      this._osc('sine', freq, t + 0.7 + i * 0.02, 0.8, 0.2);
+    });
+    // Noise burst
+    const burstSize = this.ctx.sampleRate * 0.15;
+    const burst = this.ctx.createBuffer(1, burstSize, this.ctx.sampleRate);
+    const bd = burst.getChannelData(0);
+    for (let i = 0; i < burstSize; i++) bd[i] = (Math.random() * 2 - 1);
+    const noiseSource = this.ctx.createBufferSource();
+    noiseSource.buffer = burst;
+    const noiseFilter = this.ctx.createBiquadFilter();
+    noiseFilter.type = 'bandpass';
+    noiseFilter.frequency.value = 1000;
+    const noiseGain = this.ctx.createGain();
+    noiseGain.gain.setValueAtTime(0.5, t + 0.65);
+    noiseGain.gain.exponentialRampToValueAtTime(0.0001, t + 0.85);
+    noiseSource.connect(noiseFilter);
+    noiseFilter.connect(noiseGain);
+    noiseGain.connect(this.masterGain);
+    noiseSource.start(t + 0.65);
+  }
+
+  // Lose/miss sound
+  playLose() {
+    this._ensureRunning();
+    if (!this.ctx) return;
+    const t = this._now();
+    this._osc('sawtooth', 220, t, 0.2, 0.18, 110);
+    this._osc('sawtooth', 180, t + 0.05, 0.18, 0.12, 90);
+  }
+
+  // Free spin trigger fanfare
+  playFreeSpinTrigger() {
+    this._ensureRunning();
+    if (!this.ctx) return;
+    const t = this._now();
+    // Wild ascending arpeggio
+    const notes = [261.63, 392, 523.25, 659.25, 783.99, 1046.5];
+    notes.forEach((freq, i) => {
+      this._osc('square', freq, t + i * 0.09, 0.25, 0.3);
+      this._osc('triangle', freq * 1.5, t + i * 0.09, 0.2, 0.15);
+    });
+    // Hold chord
+    [523.25, 659.25, 783.99].forEach((freq, i) => {
+      this._osc('sine', freq, t + 0.6 + i * 0.05, 1.0, 0.2);
+    });
+  }
+
+  // Free spin individual spin sound (lighter)
+  playFreeSpin() {
+    this._ensureRunning();
+    if (!this.ctx) return;
+    const t = this._now();
+    this._osc('triangle', 880, t, 0.05, 0.15, 660);
+    this._osc('triangle', 660, t + 0.04, 0.05, 0.1, 440);
+  }
+
+  // Button click
+  playButtonClick() {
+    this._ensureRunning();
+    if (!this.ctx) return;
+    const t = this._now();
+    this._osc('sine', 440, t, 0.04, 0.1, 440);
+  }
+
+  // Streak bonus notification
+  playStreakUp() {
+    this._ensureRunning();
+    if (!this.ctx) return;
+    const t = this._now();
+    [523.25, 783.99, 1046.5].forEach((freq, i) => {
+      this._osc('sine', freq, t + i * 0.06, 0.12, 0.2);
+    });
+  }
+
+  setVolume(val) {
+    if (this.masterGain) {
+      this.masterGain.gain.value = Math.max(0, Math.min(1, val));
+    }
+  }
+
+  toggleMute() {
+    this.enabled = !this.enabled;
+    if (this.masterGain) {
+      this.masterGain.gain.value = this.enabled ? 0.7 : 0;
+    }
+    return this.enabled;
+  }
+}
+
+window.PachislotAudioV2 = PachislotAudio;

--- a/src-v2/engine.js
+++ b/src-v2/engine.js
@@ -55,23 +55,6 @@ const RULES = {
   ],
 };
 
-// Reel strips - each reel has a strip of symbol keys
-// Weighted by repeating symbols proportionally
-function buildReelStrip() {
-  const strip = [];
-  for (const sym of SYMBOLS) {
-    for (let i = 0; i < sym.weight; i++) {
-      strip.push(sym.key);
-    }
-  }
-  // Shuffle
-  for (let i = strip.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [strip[i], strip[j]] = [strip[j], strip[i]];
-  }
-  return strip;
-}
-
 // ============================================================
 // WEIGHTED RANDOM PICK
 // ============================================================
@@ -244,9 +227,9 @@ class SlotEngine {
     let finalWin = baseWin;
 
     if (baseWin > 0) {
+      this.winStreak++;
       multiplier = streakMultiplier(this.winStreak);
       finalWin = Math.round(baseWin * multiplier);
-      this.winStreak++;
     } else {
       this.winStreak = 0;
     }
@@ -274,11 +257,12 @@ class SlotEngine {
       }
     }
 
-    // Classify win level
+    // Classify win level (use actual line cost for threshold, not 0 during free spins)
+    const effectiveCost = Math.max(cost, activePaylines * betPerLine);
     let winLevel = 'none';
     if (isJackpot) winLevel = 'jackpot';
-    else if (finalWin >= cost * 20) winLevel = 'bigwin';
-    else if (finalWin >= cost * 5) winLevel = 'win';
+    else if (finalWin >= effectiveCost * 20) winLevel = 'bigwin';
+    else if (finalWin >= effectiveCost * 5) winLevel = 'win';
     else if (finalWin > 0) winLevel = 'small';
 
     return {

--- a/src-v2/engine.js
+++ b/src-v2/engine.js
@@ -1,0 +1,309 @@
+/**
+ * engine.js - V2 Pachislot Game Engine
+ * Handles all game logic: reels, paylines, wins, bonuses, streak multipliers
+ */
+
+'use strict';
+
+// ============================================================
+// SYMBOLS
+// Each symbol has: key, label (emoji), name, weight, payout
+// ============================================================
+const SYMBOLS = [
+  { key: 'SEVEN',  label: '7',  name: '7',      weight: 3,  payout: 50  },
+  { key: 'BAR',    label: 'BAR', name: 'BAR',   weight: 6,  payout: 20  },
+  { key: 'BELL',   label: '🔔', name: 'ベル',   weight: 12, payout: 5   },
+  { key: 'WATERMELON', label: '🍉', name: 'スイカ', weight: 14, payout: 10 },
+  { key: 'CHERRY', label: '🍒', name: 'チェリー', weight: 20, payout: 2  },
+  { key: 'GRAPE',  label: '🍇', name: 'ブドウ', weight: 22, payout: 3   },
+  { key: 'LEMON',  label: '🍋', name: 'レモン', weight: 23, payout: 3   },
+];
+
+// Key lookup for fast access
+const SYMBOL_MAP = Object.fromEntries(SYMBOLS.map(s => [s.key, s]));
+
+// ============================================================
+// RULES
+// ============================================================
+const RULES = {
+  startingCredit: 100,
+  minBet: 1,
+  maxBet: 3,
+  reelCount: 3,
+  rowCount: 3,         // 3 visible rows per reel
+  paylines: [
+    // Each payline is an array of [reelIndex, rowIndex] positions
+    // Payline 0: middle row (always active)
+    [[0,1],[1,1],[2,1]],
+    // Payline 1: top row
+    [[0,0],[1,0],[2,0]],
+    // Payline 2: bottom row
+    [[0,2],[1,2],[2,2]],
+    // Payline 3: diagonal top-left to bottom-right
+    [[0,0],[1,1],[2,2]],
+    // Payline 4: diagonal bottom-left to top-right
+    [[0,2],[1,1],[2,0]],
+  ],
+  freeSpinTriggerKey: 'SEVEN',   // 3x SEVEN = jackpot free spins
+  freeSpinCount: 15,
+  cherryAnyPayout: 2,            // 1+ cherry anywhere = 2x bet
+  // Streak multipliers
+  streakThresholds: [
+    { min: 5, mult: 3.0 },
+    { min: 3, mult: 2.0 },
+    { min: 2, mult: 1.5 },
+  ],
+};
+
+// Reel strips - each reel has a strip of symbol keys
+// Weighted by repeating symbols proportionally
+function buildReelStrip() {
+  const strip = [];
+  for (const sym of SYMBOLS) {
+    for (let i = 0; i < sym.weight; i++) {
+      strip.push(sym.key);
+    }
+  }
+  // Shuffle
+  for (let i = strip.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [strip[i], strip[j]] = [strip[j], strip[i]];
+  }
+  return strip;
+}
+
+// ============================================================
+// WEIGHTED RANDOM PICK
+// ============================================================
+function pickWeightedSymbol() {
+  const total = SYMBOLS.reduce((sum, s) => sum + s.weight, 0);
+  let roll = Math.random() * total;
+  for (const sym of SYMBOLS) {
+    roll -= sym.weight;
+    if (roll <= 0) return sym;
+  }
+  return SYMBOLS[SYMBOLS.length - 1];
+}
+
+// Pick 3 symbols for one reel (the visible window: top, center, bottom)
+function spinReel() {
+  return [pickWeightedSymbol(), pickWeightedSymbol(), pickWeightedSymbol()];
+}
+
+// ============================================================
+// STREAK MULTIPLIER
+// ============================================================
+function streakMultiplier(streak) {
+  for (const { min, mult } of RULES.streakThresholds) {
+    if (streak >= min) return mult;
+  }
+  return 1.0;
+}
+
+// ============================================================
+// PAYLINE EVALUATION
+// reelWindows: array of 3 arrays, each containing 3 symbols (rows 0,1,2)
+// activePaylines: number of active paylines (1-5), based on bet
+// bet: bet per payline
+// ============================================================
+function evaluatePaylines(reelWindows, activePaylines, betPerLine) {
+  const wins = [];
+  let totalWin = 0;
+  let isJackpot = false;
+
+  for (let pi = 0; pi < activePaylines; pi++) {
+    const payline = RULES.paylines[pi];
+    const symbols = payline.map(([r, row]) => reelWindows[r][row]);
+    const keys = symbols.map(s => s.key);
+
+    // Check all same
+    if (keys[0] === keys[1] && keys[1] === keys[2]) {
+      const sym = SYMBOL_MAP[keys[0]];
+      const amount = sym.payout * betPerLine;
+      totalWin += amount;
+      wins.push({ paylineIndex: pi, symbols, key: keys[0], amount, type: 'match3' });
+      if (keys[0] === RULES.freeSpinTriggerKey) {
+        isJackpot = true;
+      }
+    } else {
+      // Check cherry special: any cherry on this payline = small win
+      const cherryCount = keys.filter(k => k === 'CHERRY').length;
+      if (cherryCount >= 1 && pi === 0) { // Only on center payline for single cherry
+        const amount = RULES.cherryAnyPayout * betPerLine;
+        totalWin += amount;
+        wins.push({ paylineIndex: pi, symbols, key: 'CHERRY', amount, type: 'cherry' });
+      }
+    }
+  }
+
+  return { wins, totalWin, isJackpot };
+}
+
+// ============================================================
+// SLOT ENGINE CLASS
+// ============================================================
+class SlotEngine {
+  constructor() {
+    this.credit = RULES.startingCredit;
+    this.bet = RULES.minBet;          // bet = number of lines (1-3 maps to 1-5 paylines)
+    this.lastWin = 0;
+    this.winStreak = 0;
+    this.lastMultiplier = 1;
+    this.isFreeSpinMode = false;
+    this.freeSpinsLeft = 0;
+    this.totalWon = 0;
+    this.totalSpun = 0;
+    this.biggestWin = 0;
+    // Store last reel windows for display
+    this.lastReelWindows = null;
+    this.lastPaylineResult = null;
+  }
+
+  // Active paylines = bet count (1 bet = 1 line, 2 = 3 lines, 3 = 5 lines)
+  getActivePaylines() {
+    if (this.bet === 1) return 1;
+    if (this.bet === 2) return 3;
+    return 5;
+  }
+
+  getBetPerLine() {
+    return 1; // always 1 credit per active payline
+  }
+
+  getTotalBetCost() {
+    if (this.isFreeSpinMode) return 0;
+    return this.getActivePaylines() * this.getBetPerLine();
+  }
+
+  canSpin() {
+    return this.isFreeSpinMode || this.credit >= this.getTotalBetCost();
+  }
+
+  setBet(value) {
+    this.bet = Math.max(RULES.minBet, Math.min(RULES.maxBet, value));
+    return this.bet;
+  }
+
+  increaseBet() {
+    return this.setBet(this.bet + 1);
+  }
+
+  decreaseBet() {
+    return this.setBet(this.bet - 1);
+  }
+
+  setMaxBet() {
+    return this.setBet(RULES.maxBet);
+  }
+
+  getStreakMultiplier() {
+    return streakMultiplier(this.winStreak);
+  }
+
+  reset() {
+    this.credit = RULES.startingCredit;
+    this.bet = RULES.minBet;
+    this.lastWin = 0;
+    this.winStreak = 0;
+    this.lastMultiplier = 1;
+    this.isFreeSpinMode = false;
+    this.freeSpinsLeft = 0;
+    this.totalWon = 0;
+    this.totalSpun = 0;
+    this.biggestWin = 0;
+    this.lastReelWindows = null;
+    this.lastPaylineResult = null;
+  }
+
+  spin() {
+    if (!this.canSpin()) {
+      return { success: false, error: 'クレジット不足です。ベットを下げてください。' };
+    }
+
+    const isFree = this.isFreeSpinMode;
+    const cost = this.getTotalBetCost();
+    const activePaylines = this.getActivePaylines();
+    const betPerLine = this.getBetPerLine();
+
+    if (!isFree) {
+      this.credit -= cost;
+    }
+
+    this.totalSpun++;
+
+    // Spin all reels: each reel returns [topSymbol, midSymbol, bottomSymbol]
+    const reelWindows = [spinReel(), spinReel(), spinReel()];
+    this.lastReelWindows = reelWindows;
+
+    // Evaluate paylines
+    const { wins, totalWin: baseWin, isJackpot } = evaluatePaylines(reelWindows, activePaylines, betPerLine);
+    this.lastPaylineResult = { wins, isJackpot };
+
+    // Apply streak multiplier
+    let multiplier = 1;
+    let finalWin = baseWin;
+
+    if (baseWin > 0) {
+      multiplier = streakMultiplier(this.winStreak);
+      finalWin = Math.round(baseWin * multiplier);
+      this.winStreak++;
+    } else {
+      this.winStreak = 0;
+    }
+
+    this.credit += finalWin;
+    this.lastWin = finalWin;
+    this.lastMultiplier = multiplier;
+    this.totalWon += finalWin;
+
+    if (finalWin > this.biggestWin) this.biggestWin = finalWin;
+
+    // Handle jackpot / free spin trigger
+    let freeSpinTriggered = false;
+    if (isJackpot && !isFree) {
+      this.isFreeSpinMode = true;
+      this.freeSpinsLeft = RULES.freeSpinCount;
+      freeSpinTriggered = true;
+    }
+
+    // Decrement free spins
+    if (isFree) {
+      this.freeSpinsLeft = Math.max(0, this.freeSpinsLeft - 1);
+      if (this.freeSpinsLeft === 0) {
+        this.isFreeSpinMode = false;
+      }
+    }
+
+    // Classify win level
+    let winLevel = 'none';
+    if (isJackpot) winLevel = 'jackpot';
+    else if (finalWin >= cost * 20) winLevel = 'bigwin';
+    else if (finalWin >= cost * 5) winLevel = 'win';
+    else if (finalWin > 0) winLevel = 'small';
+
+    return {
+      success: true,
+      reelWindows,
+      wins,
+      win: finalWin,
+      baseWin,
+      multiplier,
+      winLevel,
+      isJackpot,
+      isFree,
+      freeSpinTriggered,
+      freeSpinsLeft: this.freeSpinsLeft,
+      isFreeSpinMode: this.isFreeSpinMode,
+      credit: this.credit,
+      bet: this.bet,
+      activePaylines,
+      winStreak: this.winStreak,
+      cost,
+    };
+  }
+}
+
+// Export for use in ui.js
+window.SlotEngineV2 = SlotEngine;
+window.SlotSymbolsV2 = SYMBOLS;
+window.SlotRulesV2 = RULES;

--- a/src-v2/index.html
+++ b/src-v2/index.html
@@ -2,7 +2,7 @@
 <html lang="ja">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>LUCKY 777 - Pachislot V2</title>
   <link rel="stylesheet" href="./styles.css" />
 </head>
@@ -12,7 +12,7 @@
 <div id="spark-container" class="spark-container" aria-hidden="true"></div>
 
 <!-- Win banner overlay -->
-<div id="win-banner" class="win-banner" aria-hidden="true" role="status">
+<div id="win-banner" class="win-banner" aria-hidden="true" aria-live="polite" role="status">
   <div id="win-banner-text" class="win-banner-text">WIN!</div>
 </div>
 

--- a/src-v2/index.html
+++ b/src-v2/index.html
@@ -1,0 +1,223 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
+  <title>LUCKY 777 - Pachislot V2</title>
+  <link rel="stylesheet" href="./styles.css" />
+</head>
+<body>
+
+<!-- Spark overlay for win effects -->
+<div id="spark-container" class="spark-container" aria-hidden="true"></div>
+
+<!-- Win banner overlay -->
+<div id="win-banner" class="win-banner" aria-hidden="true" role="status">
+  <div id="win-banner-text" class="win-banner-text">WIN!</div>
+</div>
+
+<!-- Main cabinet wrapper -->
+<div class="cabinet-wrapper">
+  <div class="cabinet" role="main" aria-label="パチスロ LUCKY 777">
+
+    <!-- ========== MARQUEE ========== -->
+    <header class="cabinet-marquee">
+      <div class="marquee-title">LUCKY 777</div>
+      <div class="marquee-sub">PACHISLOT &bull; V2 &bull; SPECIAL EDITION</div>
+      <div class="marquee-lights" aria-hidden="true">
+        <span class="marquee-light"></span>
+        <span class="marquee-light"></span>
+        <span class="marquee-light"></span>
+        <span class="marquee-light"></span>
+        <span class="marquee-light"></span>
+        <span class="marquee-light"></span>
+        <span class="marquee-light"></span>
+        <span class="marquee-light"></span>
+      </div>
+    </header>
+
+    <!-- ========== LED STATUS DISPLAYS ========== -->
+    <section class="status-panel" aria-label="スコア表示">
+      <div class="led-group">
+        <span class="led-label">CREDIT</span>
+        <span id="credit-display" class="led-value" aria-label="クレジット">000100</span>
+      </div>
+      <div class="led-group">
+        <span class="led-label">WIN</span>
+        <span id="win-display" class="led-value" aria-label="獲得枚数">0000</span>
+      </div>
+      <div class="led-group">
+        <span class="led-label">STREAK×</span>
+        <span id="multiplier-display" class="led-value" aria-label="連勝倍率">×1.0</span>
+      </div>
+    </section>
+
+    <!-- Secondary status row -->
+    <section class="status-panel" style="grid-template-columns: repeat(2,1fr); padding-top: 4px; padding-bottom: 4px;" aria-label="詳細表示">
+      <div class="led-group">
+        <span class="led-label">BET</span>
+        <span id="bet-display" class="led-value" style="font-size:16px;" aria-label="ベット">1</span>
+      </div>
+      <div class="led-group">
+        <span class="led-label">STREAK</span>
+        <span id="streak-display" class="led-value" style="font-size:16px;" aria-label="連勝数">0</span>
+      </div>
+    </section>
+
+    <!-- ========== FREE SPIN PANEL ========== -->
+    <div id="freespins-panel" class="freespins-panel" role="status" aria-live="polite">
+      <span class="freespins-label">FREE SPIN</span>
+      <span id="freespins-display" class="freespins-count">0</span>
+      <span class="freespins-label">残り</span>
+    </div>
+
+    <!-- ========== PAYLINE INDICATOR ========== -->
+    <div class="payline-bar" aria-label="ペイライン" aria-hidden="true">
+      <div class="payline-indicator" title="センターライン"></div>
+      <div class="payline-indicator" title="トップライン"></div>
+      <div class="payline-indicator" title="ボトムライン"></div>
+      <div class="payline-indicator" title="対角1"></div>
+      <div class="payline-indicator" title="対角2"></div>
+      <span class="paylines-text" id="paylines-display">LINES: 1</span>
+    </div>
+
+    <!-- ========== REEL WINDOW ========== -->
+    <section class="reel-section" aria-label="リール">
+      <div class="reel-frame">
+        <div class="reels-row">
+
+          <!-- Reel 0 -->
+          <div id="reel-0" class="reel" aria-label="リール1">
+            <div class="reel-cell sym-cherry">🍒</div>
+            <div class="reel-cell sym-seven center-row center-row-marker">7</div>
+            <div class="reel-cell sym-bell">🔔</div>
+          </div>
+
+          <!-- Reel 1 -->
+          <div id="reel-1" class="reel" aria-label="リール2">
+            <div class="reel-cell sym-bell">🔔</div>
+            <div class="reel-cell sym-bar center-row center-row-marker">BAR</div>
+            <div class="reel-cell sym-lemon">🍋</div>
+          </div>
+
+          <!-- Reel 2 -->
+          <div id="reel-2" class="reel" aria-label="リール3">
+            <div class="reel-cell sym-lemon">🍋</div>
+            <div class="reel-cell sym-watermelon center-row center-row-marker">🍉</div>
+            <div class="reel-cell sym-grape">🍇</div>
+          </div>
+
+        </div>
+      </div>
+    </section>
+
+    <!-- ========== CONTROLS ========== -->
+    <section class="controls-section" aria-label="操作パネル">
+
+      <!-- Bet buttons -->
+      <div class="bet-row">
+        <button id="btn-bet1" class="btn-bet" type="button" aria-label="1BET: 1ライン">
+          1 BET
+        </button>
+        <button id="btn-betmax" class="btn-bet" type="button" aria-label="MAX BET: 5ライン">
+          MAX BET
+        </button>
+      </div>
+
+      <!-- SPIN button -->
+      <div class="spin-row">
+        <button id="btn-spin" class="btn-spin" type="button" aria-label="スピン">
+          SPIN
+        </button>
+      </div>
+
+      <!-- Utility buttons -->
+      <div class="util-row">
+        <button id="btn-reset" class="btn-util" type="button" aria-label="リセット">
+          RESET
+        </button>
+        <button id="btn-mute" class="btn-util" type="button" aria-label="ミュート" title="ミュート">
+          🔊 SOUND
+        </button>
+      </div>
+
+    </section>
+
+    <!-- ========== MESSAGE DISPLAY ========== -->
+    <div class="message-panel">
+      <div id="message-display" class="message-display" aria-live="polite" role="status">
+        SPIN を押してスタート！
+      </div>
+    </div>
+
+    <!-- ========== PAY TABLE ========== -->
+    <section class="paytable-panel" aria-label="ペイテーブル">
+      <div class="paytable-title">PAY TABLE (BET×)</div>
+      <div class="paytable-grid">
+        <div class="pay-row">
+          <span class="pay-symbol">7 7 7</span>
+          <span class="pay-amount">50+ JACKPOT</span>
+        </div>
+        <div class="pay-row">
+          <span class="pay-symbol">🍉🍉🍉</span>
+          <span class="pay-amount">×10</span>
+        </div>
+        <div class="pay-row">
+          <span class="pay-symbol">BAR×3</span>
+          <span class="pay-amount">×20</span>
+        </div>
+        <div class="pay-row">
+          <span class="pay-symbol">🔔🔔🔔</span>
+          <span class="pay-amount">×5</span>
+        </div>
+        <div class="pay-row">
+          <span class="pay-symbol">🍇🍇🍇</span>
+          <span class="pay-amount">×3</span>
+        </div>
+        <div class="pay-row">
+          <span class="pay-symbol">🍋🍋🍋</span>
+          <span class="pay-amount">×3</span>
+        </div>
+        <div class="pay-row">
+          <span class="pay-symbol">🍒🍒🍒</span>
+          <span class="pay-amount">×2</span>
+        </div>
+        <div class="pay-row">
+          <span class="pay-symbol">🍒 any</span>
+          <span class="pay-amount">×2</span>
+        </div>
+        <div class="pay-row" style="font-size:9px; color:#555; border:none; grid-column: span 1">
+          <span>777=FREE×15</span>
+        </div>
+      </div>
+    </section>
+
+    <!-- ========== BOTTOM DECORATION ========== -->
+    <div class="cabinet-bottom" aria-hidden="true">
+      <div class="bottom-lights">
+        <span class="bottom-light"></span>
+        <span class="bottom-light"></span>
+        <span class="bottom-light"></span>
+        <span class="bottom-light"></span>
+        <span class="bottom-light"></span>
+      </div>
+      <span class="version-text">V2.0.0 &copy; LUCKY 777</span>
+      <div class="bottom-lights">
+        <span class="bottom-light" style="animation-direction:reverse"></span>
+        <span class="bottom-light" style="animation-direction:reverse"></span>
+        <span class="bottom-light" style="animation-direction:reverse"></span>
+        <span class="bottom-light" style="animation-direction:reverse"></span>
+        <span class="bottom-light" style="animation-direction:reverse"></span>
+      </div>
+    </div>
+
+  </div><!-- /.cabinet -->
+</div><!-- /.cabinet-wrapper -->
+
+<!-- Scripts: engine first, then audio, then UI -->
+<script src="./engine.js"></script>
+<script src="./audio.js"></script>
+<script src="./ui.js"></script>
+
+</body>
+</html>

--- a/src-v2/styles.css
+++ b/src-v2/styles.css
@@ -1,0 +1,864 @@
+/* ============================================================
+   styles.css - V2 Pachislot - Authentic Cabinet Design
+   ============================================================ */
+
+/* ---- Reset & Base ---- */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --cabinet-bg: #1a0a00;
+  --cabinet-frame: #2d1500;
+  --cabinet-panel: #0d0d0d;
+  --accent-red: #cc0000;
+  --accent-gold: #ffd700;
+  --accent-orange: #ff6b00;
+  --accent-cyan: #00e5ff;
+  --accent-green: #00ff88;
+  --led-bg: #001a00;
+  --led-on: #00ff44;
+  --led-dim: #003300;
+  --reel-bg: #f5f5dc;
+  --reel-border: #888;
+  --text-bright: #fff;
+  --text-dim: #888;
+  --btn-spin-from: #cc0000;
+  --btn-spin-to: #880000;
+  --font-led: 'Courier New', 'Lucida Console', monospace;
+}
+
+html, body {
+  height: 100%;
+  background: #000;
+  color: var(--text-bright);
+  font-family: 'Arial Black', 'Impact', 'Arial', sans-serif;
+  overflow-x: hidden;
+}
+
+/* ============================================================
+   CABINET WRAPPER
+   ============================================================ */
+.cabinet-wrapper {
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  min-height: 100vh;
+  background: radial-gradient(ellipse at center, #1a0505 0%, #000 70%);
+  padding: 16px 8px;
+}
+
+.cabinet {
+  width: 100%;
+  max-width: 480px;
+  background: linear-gradient(180deg, #2a0800 0%, #1a0500 40%, #0d0d0d 100%);
+  border: 3px solid #3d1a00;
+  border-radius: 24px 24px 12px 12px;
+  box-shadow:
+    0 0 60px rgba(204,0,0,0.4),
+    0 0 120px rgba(204,0,0,0.15),
+    inset 0 2px 0 rgba(255,255,255,0.1);
+  overflow: hidden;
+  position: relative;
+}
+
+/* ============================================================
+   TOP MARQUEE
+   ============================================================ */
+.cabinet-marquee {
+  background: linear-gradient(90deg, #000 0%, #1a0000 20%, #300000 50%, #1a0000 80%, #000 100%);
+  border-bottom: 2px solid #cc0000;
+  padding: 12px 16px 10px;
+  text-align: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.cabinet-marquee::before,
+.cabinet-marquee::after {
+  content: '';
+  position: absolute;
+  top: 0; bottom: 0;
+  width: 4px;
+  background: linear-gradient(180deg, #ffd700, #ff6b00, #ffd700);
+}
+.cabinet-marquee::before { left: 8px; }
+.cabinet-marquee::after  { right: 8px; }
+
+.marquee-title {
+  font-size: 26px;
+  font-weight: 900;
+  letter-spacing: 4px;
+  color: var(--accent-gold);
+  text-shadow:
+    0 0 10px #ffd700,
+    0 0 20px #ff6b00,
+    0 0 40px #ff0000;
+  text-transform: uppercase;
+  animation: marquee-pulse 1.5s ease-in-out infinite alternate;
+}
+
+.marquee-sub {
+  font-size: 11px;
+  letter-spacing: 6px;
+  color: var(--accent-orange);
+  text-shadow: 0 0 8px #ff6b00;
+  margin-top: 2px;
+  text-transform: uppercase;
+}
+
+/* Marquee LED lights */
+.marquee-lights {
+  display: flex;
+  justify-content: center;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.marquee-light {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent-red);
+  box-shadow: 0 0 6px var(--accent-red);
+  animation: led-chase 1.2s linear infinite;
+}
+.marquee-light:nth-child(2) { animation-delay: 0.15s; }
+.marquee-light:nth-child(3) { animation-delay: 0.30s; }
+.marquee-light:nth-child(4) { animation-delay: 0.45s; }
+.marquee-light:nth-child(5) { animation-delay: 0.60s; }
+.marquee-light:nth-child(6) { animation-delay: 0.75s; }
+.marquee-light:nth-child(7) { animation-delay: 0.90s; }
+.marquee-light:nth-child(8) { animation-delay: 1.05s; }
+
+/* ============================================================
+   STATUS PANEL (LED displays)
+   ============================================================ */
+.status-panel {
+  background: var(--cabinet-panel);
+  border-bottom: 1px solid #333;
+  padding: 8px 16px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+}
+
+.led-group {
+  background: #050505;
+  border: 1px solid #333;
+  border-radius: 4px;
+  padding: 6px 8px;
+  text-align: center;
+}
+
+.led-label {
+  font-size: 9px;
+  letter-spacing: 2px;
+  color: var(--text-dim);
+  font-family: var(--font-led);
+  text-transform: uppercase;
+  display: block;
+  margin-bottom: 2px;
+}
+
+.led-value {
+  font-family: var(--font-led);
+  font-size: 20px;
+  color: var(--led-on);
+  text-shadow: 0 0 8px #00ff44, 0 0 16px #00aa22;
+  letter-spacing: 2px;
+  display: block;
+}
+
+.led-value.mult-x1-5 {
+  color: #ffee00;
+  text-shadow: 0 0 8px #ffee00, 0 0 16px #aa9900;
+}
+.led-value.mult-x2 {
+  color: var(--accent-orange);
+  text-shadow: 0 0 8px #ff6b00, 0 0 16px #cc4400;
+}
+.led-value.mult-x3 {
+  color: var(--accent-gold);
+  text-shadow: 0 0 10px #ffd700, 0 0 20px #ff6b00;
+  animation: gold-pulse 0.5s ease-in-out infinite alternate;
+}
+
+/* ============================================================
+   FREE SPIN PANEL
+   ============================================================ */
+.freespins-panel {
+  display: none;
+  background: linear-gradient(90deg, #000044, #000088, #000044);
+  border-top: 1px solid #4444ff;
+  border-bottom: 1px solid #4444ff;
+  padding: 6px 16px;
+  text-align: center;
+  animation: freespin-pulse 0.8s ease-in-out infinite alternate;
+}
+
+.freespins-panel.active {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
+}
+
+.freespins-label {
+  font-size: 13px;
+  letter-spacing: 3px;
+  color: #88aaff;
+  text-transform: uppercase;
+}
+
+.freespins-count {
+  font-family: var(--font-led);
+  font-size: 24px;
+  color: #aaccff;
+  text-shadow: 0 0 10px #4488ff, 0 0 20px #0044ff;
+}
+
+/* ============================================================
+   PAYLINE INDICATOR BAR
+   ============================================================ */
+.payline-bar {
+  display: flex;
+  justify-content: center;
+  gap: 6px;
+  padding: 6px 16px;
+  background: #050505;
+  border-bottom: 1px solid #222;
+}
+
+.payline-indicator {
+  width: 32px;
+  height: 6px;
+  border-radius: 3px;
+  background: #222;
+  border: 1px solid #333;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.payline-indicator.active {
+  background: var(--accent-gold);
+  box-shadow: 0 0 6px var(--accent-gold);
+}
+
+.payline-indicator:nth-child(1).active { background: #ff4444; box-shadow: 0 0 6px #ff4444; }
+.payline-indicator:nth-child(2).active { background: #44ff44; box-shadow: 0 0 6px #44ff44; }
+.payline-indicator:nth-child(3).active { background: #4444ff; box-shadow: 0 0 6px #4444ff; }
+.payline-indicator:nth-child(4).active { background: #ffff44; box-shadow: 0 0 6px #ffff44; }
+.payline-indicator:nth-child(5).active { background: #ff44ff; box-shadow: 0 0 6px #ff44ff; }
+
+.paylines-text {
+  font-size: 10px;
+  letter-spacing: 2px;
+  color: var(--text-dim);
+  display: flex;
+  align-items: center;
+}
+
+/* ============================================================
+   REEL WINDOW
+   ============================================================ */
+.reel-section {
+  padding: 12px 16px;
+  background: var(--cabinet-panel);
+}
+
+.reel-frame {
+  background: #111;
+  border: 3px solid #444;
+  border-radius: 8px;
+  padding: 8px;
+  box-shadow:
+    inset 0 4px 12px rgba(0,0,0,0.8),
+    0 0 20px rgba(0,0,0,0.5);
+  position: relative;
+}
+
+/* Center payline glow bar */
+.reel-frame::after {
+  content: '';
+  position: absolute;
+  left: 8px;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  height: 68px;
+  border: 2px solid rgba(255,0,0,0.3);
+  border-radius: 4px;
+  pointer-events: none;
+  box-shadow: 0 0 8px rgba(255,0,0,0.2), inset 0 0 8px rgba(255,0,0,0.05);
+  z-index: 10;
+}
+
+.reels-row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+}
+
+.reel {
+  background: linear-gradient(180deg, #f8f8f0 0%, #fff 50%, #f8f8f0 100%);
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  overflow: hidden;
+  box-shadow: inset 0 2px 4px rgba(0,0,0,0.2);
+  position: relative;
+}
+
+.reel.spinning::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    180deg,
+    rgba(255,255,255,0.6) 0%,
+    transparent 20%,
+    transparent 80%,
+    rgba(255,255,255,0.6) 100%
+  );
+  pointer-events: none;
+  z-index: 5;
+  animation: reel-blur 0.05s linear infinite;
+}
+
+.reel-cell {
+  height: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 30px;
+  font-weight: 900;
+  border-bottom: 1px solid #e0e0e0;
+  color: #222;
+  position: relative;
+  background: #fff;
+  user-select: none;
+  transition: transform 0.1s;
+}
+
+.reel-cell:last-child { border-bottom: none; }
+
+/* Center row highlight */
+.reel-cell.center-row {
+  background: #fffef0;
+  border-top: 2px solid rgba(255,150,0,0.3);
+  border-bottom: 2px solid rgba(255,150,0,0.3);
+}
+
+/* Symbol colors */
+.reel-cell.sym-seven {
+  color: #cc0000;
+  text-shadow: 0 1px 0 #880000;
+  font-size: 28px;
+  font-family: 'Arial Black', 'Impact', sans-serif;
+  font-weight: 900;
+  background: linear-gradient(180deg, #fff8f8 0%, #fff 100%);
+}
+
+.reel-cell.sym-bar {
+  color: #fff;
+  background: linear-gradient(180deg, #222 0%, #444 50%, #222 100%);
+  font-family: 'Arial Black', 'Impact', sans-serif;
+  font-size: 18px;
+  font-weight: 900;
+  letter-spacing: 1px;
+  border-color: #555;
+}
+
+/* Stop pop animation */
+.reel-cell.stop-pop {
+  animation: cell-pop 0.25s cubic-bezier(0.36, 0.07, 0.19, 0.97);
+}
+
+/* Win highlight */
+.reel-cell.win-cell {
+  animation: win-flash 0.25s ease-in-out 5 alternate;
+  z-index: 2;
+}
+
+/* Spinning frame scramble */
+.reel-cell.spinning-frame {
+  animation: frame-scramble 0.05s linear;
+}
+
+/* ============================================================
+   CONTROL PANELS
+   ============================================================ */
+.controls-section {
+  padding: 12px 16px;
+  background: linear-gradient(180deg, #0a0a0a 0%, #050505 100%);
+  border-top: 2px solid #222;
+}
+
+/* Bet buttons row */
+.bet-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.btn-bet {
+  background: linear-gradient(180deg, #2a2a00 0%, #1a1a00 100%);
+  border: 2px solid #555500;
+  border-radius: 8px;
+  color: var(--accent-gold);
+  font-size: 14px;
+  font-weight: 900;
+  letter-spacing: 2px;
+  padding: 10px 8px;
+  cursor: pointer;
+  text-transform: uppercase;
+  transition: all 0.1s;
+  box-shadow: 0 3px 0 #111100, 0 0 10px rgba(255,215,0,0.1);
+}
+
+.btn-bet:hover:not(:disabled) {
+  background: linear-gradient(180deg, #3a3a00 0%, #2a2a00 100%);
+  box-shadow: 0 3px 0 #111100, 0 0 15px rgba(255,215,0,0.3);
+}
+
+.btn-bet:active:not(:disabled) {
+  transform: translateY(2px);
+  box-shadow: 0 1px 0 #111100;
+}
+
+.btn-bet:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* Spin button */
+.spin-row {
+  margin-bottom: 10px;
+}
+
+.btn-spin {
+  width: 100%;
+  background: linear-gradient(180deg, #ff2200 0%, #cc0000 40%, #880000 100%);
+  border: none;
+  border-radius: 12px;
+  color: #fff;
+  font-size: 28px;
+  font-weight: 900;
+  letter-spacing: 6px;
+  padding: 16px 8px;
+  cursor: pointer;
+  text-transform: uppercase;
+  text-shadow: 0 2px 4px rgba(0,0,0,0.5);
+  box-shadow:
+    0 6px 0 #440000,
+    0 0 20px rgba(255,0,0,0.4),
+    inset 0 1px 0 rgba(255,255,255,0.2);
+  transition: all 0.1s;
+  position: relative;
+  overflow: hidden;
+}
+
+.btn-spin::before {
+  content: '';
+  position: absolute;
+  top: 0; left: -100%;
+  width: 60%;
+  height: 100%;
+  background: linear-gradient(90deg, transparent, rgba(255,255,255,0.15), transparent);
+  animation: btn-shine 3s linear infinite;
+}
+
+.btn-spin:hover:not(:disabled) {
+  background: linear-gradient(180deg, #ff4400 0%, #ee0000 40%, #aa0000 100%);
+  box-shadow:
+    0 6px 0 #440000,
+    0 0 30px rgba(255,0,0,0.6),
+    inset 0 1px 0 rgba(255,255,255,0.2);
+}
+
+.btn-spin:active:not(:disabled) {
+  transform: translateY(4px);
+  box-shadow:
+    0 2px 0 #440000,
+    0 0 20px rgba(255,0,0,0.3);
+}
+
+.btn-spin:disabled {
+  background: linear-gradient(180deg, #444 0%, #333 100%);
+  box-shadow: 0 4px 0 #111;
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+/* Utility buttons row */
+.util-row {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 8px;
+}
+
+.btn-util {
+  background: linear-gradient(180deg, #1a1a1a 0%, #0d0d0d 100%);
+  border: 1px solid #333;
+  border-radius: 6px;
+  color: #888;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  padding: 8px 6px;
+  cursor: pointer;
+  text-transform: uppercase;
+  transition: all 0.1s;
+}
+
+.btn-util:hover:not(:disabled) {
+  background: linear-gradient(180deg, #252525 0%, #1a1a1a 100%);
+  color: #bbb;
+  border-color: #555;
+}
+
+.btn-util:active:not(:disabled) {
+  transform: translateY(1px);
+}
+
+/* ============================================================
+   MESSAGE DISPLAY
+   ============================================================ */
+.message-panel {
+  padding: 8px 16px;
+  background: #050505;
+  border-top: 1px solid #222;
+  min-height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.message-display {
+  font-family: var(--font-led);
+  font-size: 13px;
+  letter-spacing: 1px;
+  color: #666;
+  text-align: center;
+}
+
+.message-display.msg-win {
+  color: var(--accent-gold);
+  text-shadow: 0 0 8px #ffd700;
+  animation: msg-pop 0.3s ease-out;
+}
+
+.message-display.msg-lose {
+  color: #555;
+}
+
+.message-display.msg-spinning {
+  color: var(--accent-cyan);
+  animation: blink 0.5s ease-in-out infinite;
+}
+
+.message-display.msg-error {
+  color: #ff4444;
+}
+
+.message-display.msg-freespin {
+  color: #88aaff;
+  text-shadow: 0 0 8px #4488ff;
+}
+
+/* ============================================================
+   PAY TABLE
+   ============================================================ */
+.paytable-panel {
+  background: #050505;
+  border-top: 1px solid #222;
+  padding: 10px 16px;
+}
+
+.paytable-title {
+  font-size: 10px;
+  letter-spacing: 4px;
+  color: var(--text-dim);
+  text-align: center;
+  margin-bottom: 8px;
+  text-transform: uppercase;
+}
+
+.paytable-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 4px 8px;
+}
+
+.pay-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 11px;
+  padding: 3px 0;
+  border-bottom: 1px solid #111;
+}
+
+.pay-symbol {
+  font-size: 13px;
+}
+
+.pay-amount {
+  color: var(--accent-gold);
+  font-family: var(--font-led);
+  font-size: 11px;
+}
+
+/* ============================================================
+   WIN BANNER OVERLAY
+   ============================================================ */
+.win-banner {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0);
+  z-index: 1000;
+  text-align: center;
+  pointer-events: none;
+  transition: none;
+}
+
+.win-banner.show {
+  animation: banner-appear 0.3s cubic-bezier(0.36, 0.07, 0.19, 0.97) forwards;
+}
+
+.win-banner-text {
+  display: inline-block;
+  font-size: 48px;
+  font-weight: 900;
+  letter-spacing: 4px;
+  padding: 16px 32px;
+  border-radius: 8px;
+  text-shadow: 0 4px 8px rgba(0,0,0,0.8);
+}
+
+.win-banner.level-small .win-banner-text {
+  color: #fff;
+  background: rgba(0,100,0,0.85);
+  border: 2px solid #00ff44;
+}
+
+.win-banner.level-win .win-banner-text {
+  color: var(--accent-gold);
+  background: rgba(0,0,0,0.85);
+  border: 3px solid var(--accent-gold);
+  box-shadow: 0 0 30px var(--accent-gold);
+}
+
+.win-banner.level-bigwin .win-banner-text {
+  color: #fff;
+  background: rgba(100,0,0,0.9);
+  border: 3px solid #ff6b00;
+  box-shadow: 0 0 40px #ff6b00, 0 0 80px rgba(255,107,0,0.5);
+  animation: bigwin-shake 0.1s ease-in-out infinite;
+  font-size: 52px;
+}
+
+.win-banner.level-jackpot .win-banner-text {
+  color: var(--accent-gold);
+  background: rgba(0,0,0,0.95);
+  border: 4px solid var(--accent-gold);
+  box-shadow:
+    0 0 30px var(--accent-gold),
+    0 0 60px #ff6b00,
+    0 0 90px rgba(255,215,0,0.5);
+  animation: jackpot-pulse 0.3s ease-in-out infinite alternate;
+  font-size: 56px;
+}
+
+.win-banner.level-freespin .win-banner-text {
+  color: #88aaff;
+  background: rgba(0,0,50,0.95);
+  border: 3px solid #4488ff;
+  box-shadow: 0 0 30px #4488ff;
+  font-size: 36px;
+}
+
+/* ============================================================
+   SPARK CONTAINER
+   ============================================================ */
+.spark-container {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 999;
+  overflow: hidden;
+}
+
+.spark {
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--sc, #ffd700);
+  box-shadow: 0 0 6px var(--sc, #ffd700);
+  animation: spark-fly var(--dur, 0.7s) ease-out forwards;
+}
+
+/* ============================================================
+   BODY WIN MODES
+   ============================================================ */
+body.jackpot-mode {
+  animation: jackpot-screen 0.2s linear infinite;
+}
+
+body.bigwin-mode {
+  animation: bigwin-screen 0.4s linear infinite alternate;
+}
+
+/* ============================================================
+   BOTTOM DECORATION
+   ============================================================ */
+.cabinet-bottom {
+  background: linear-gradient(180deg, #1a0500 0%, #0d0000 100%);
+  border-top: 2px solid #3d1a00;
+  padding: 8px 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.bottom-lights {
+  display: flex;
+  gap: 4px;
+}
+
+.bottom-light {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  animation: led-chase 0.8s linear infinite;
+}
+
+.bottom-light:nth-child(1) { background: #ff0000; box-shadow: 0 0 4px #ff0000; }
+.bottom-light:nth-child(2) { background: #ff6b00; box-shadow: 0 0 4px #ff6b00; animation-delay: 0.1s; }
+.bottom-light:nth-child(3) { background: #ffd700; box-shadow: 0 0 4px #ffd700; animation-delay: 0.2s; }
+.bottom-light:nth-child(4) { background: #00ff44; box-shadow: 0 0 4px #00ff44; animation-delay: 0.3s; }
+.bottom-light:nth-child(5) { background: #00e5ff; box-shadow: 0 0 4px #00e5ff; animation-delay: 0.4s; }
+
+.version-text {
+  font-size: 9px;
+  letter-spacing: 2px;
+  color: #333;
+  font-family: var(--font-led);
+}
+
+/* ============================================================
+   KEYFRAME ANIMATIONS
+   ============================================================ */
+
+@keyframes marquee-pulse {
+  from { text-shadow: 0 0 10px #ffd700, 0 0 20px #ff6b00, 0 0 40px #ff0000; }
+  to   { text-shadow: 0 0 20px #ffd700, 0 0 40px #ff6b00, 0 0 80px #ff0000; }
+}
+
+@keyframes led-chase {
+  0%   { opacity: 1; }
+  50%  { opacity: 0.2; }
+  100% { opacity: 1; }
+}
+
+@keyframes gold-pulse {
+  from { text-shadow: 0 0 8px #ffd700, 0 0 16px #ff6b00; }
+  to   { text-shadow: 0 0 20px #ffd700, 0 0 40px #ff6b00; }
+}
+
+@keyframes freespin-pulse {
+  from { background: linear-gradient(90deg, #000044, #000088, #000044); }
+  to   { background: linear-gradient(90deg, #000066, #0000cc, #000066); }
+}
+
+@keyframes reel-blur {
+  0%   { opacity: 0.8; }
+  50%  { opacity: 0.4; }
+  100% { opacity: 0.8; }
+}
+
+@keyframes cell-pop {
+  0%   { transform: scaleY(1.15) scaleX(0.95); }
+  50%  { transform: scaleY(0.95) scaleX(1.05); }
+  100% { transform: scaleY(1) scaleX(1); }
+}
+
+@keyframes win-flash {
+  from { background: #fff; box-shadow: inset 0 0 0 3px #ffd700; }
+  to   { background: #fff9cc; box-shadow: inset 0 0 12px #ffd700; }
+}
+
+@keyframes frame-scramble {
+  from { transform: translateY(-2px); }
+  to   { transform: translateY(2px); }
+}
+
+@keyframes btn-shine {
+  0%   { left: -100%; }
+  100% { left: 200%; }
+}
+
+@keyframes banner-appear {
+  0%   { transform: translate(-50%, -50%) scale(0) rotate(-5deg); opacity: 0; }
+  60%  { transform: translate(-50%, -50%) scale(1.15) rotate(1deg); opacity: 1; }
+  80%  { transform: translate(-50%, -50%) scale(0.95) rotate(-0.5deg); }
+  100% { transform: translate(-50%, -50%) scale(1) rotate(0); opacity: 1; }
+}
+
+@keyframes bigwin-shake {
+  0%, 100% { transform: translate(-1px, 0); }
+  50%       { transform: translate(1px, 1px); }
+}
+
+@keyframes jackpot-pulse {
+  from { box-shadow: 0 0 30px #ffd700, 0 0 60px #ff6b00; }
+  to   { box-shadow: 0 0 60px #ffd700, 0 0 120px #ff6b00, 0 0 180px rgba(255,215,0,0.5); }
+}
+
+@keyframes jackpot-screen {
+  0%   { filter: hue-rotate(0deg) brightness(1); }
+  25%  { filter: hue-rotate(90deg) brightness(1.1); }
+  50%  { filter: hue-rotate(180deg) brightness(1.2); }
+  75%  { filter: hue-rotate(270deg) brightness(1.1); }
+  100% { filter: hue-rotate(360deg) brightness(1); }
+}
+
+@keyframes bigwin-screen {
+  from { filter: brightness(1); }
+  to   { filter: brightness(1.15); }
+}
+
+@keyframes spark-fly {
+  0%   { transform: translate(0, 0) scale(1); opacity: 1; }
+  100% { transform: translate(var(--dx, 0), var(--dy, -100px)) scale(0); opacity: 0; }
+}
+
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.4; }
+}
+
+@keyframes msg-pop {
+  0%   { transform: scale(1.2); }
+  100% { transform: scale(1); }
+}
+
+/* ============================================================
+   RESPONSIVE ADJUSTMENTS
+   ============================================================ */
+@media (max-width: 400px) {
+  .marquee-title { font-size: 20px; letter-spacing: 2px; }
+  .led-value     { font-size: 16px; }
+  .reel-cell     { height: 54px; font-size: 24px; }
+  .btn-spin      { font-size: 22px; padding: 14px 8px; }
+  .win-banner-text { font-size: 36px; }
+}
+
+@media (min-width: 500px) {
+  .cabinet { max-width: 480px; }
+}
+
+/* Scrollbar */
+::-webkit-scrollbar { width: 4px; }
+::-webkit-scrollbar-track { background: #111; }
+::-webkit-scrollbar-thumb { background: #333; border-radius: 2px; }

--- a/src-v2/ui.js
+++ b/src-v2/ui.js
@@ -1,0 +1,418 @@
+/**
+ * ui.js - V2 Pachislot UI & Animation Controller
+ * Handles all DOM interactions, reel animations, effects
+ */
+
+'use strict';
+
+// ============================================================
+// INITIALIZATION - Wait for DOM ready
+// ============================================================
+document.addEventListener('DOMContentLoaded', () => {
+  const engine = new window.SlotEngineV2();
+  const audio = new window.PachislotAudioV2();
+  const SYMBOLS = window.SlotSymbolsV2;
+  const RULES = window.SlotRulesV2;
+
+  // Symbol display map
+  const SYMBOL_DISPLAY = {};
+  SYMBOLS.forEach(s => { SYMBOL_DISPLAY[s.key] = s.label; });
+
+  // Symbol color class map
+  const SYMBOL_COLOR = {
+    'SEVEN': 'sym-seven',
+    'BAR': 'sym-bar',
+    'BELL': 'sym-bell',
+    'WATERMELON': 'sym-watermelon',
+    'CHERRY': 'sym-cherry',
+    'GRAPE': 'sym-grape',
+    'LEMON': 'sym-lemon',
+  };
+
+  // ============================================================
+  // DOM REFERENCES
+  // ============================================================
+  const reelContainers = [
+    document.getElementById('reel-0'),
+    document.getElementById('reel-1'),
+    document.getElementById('reel-2'),
+  ];
+
+  const creditDisplay = document.getElementById('credit-display');
+  const betDisplay = document.getElementById('bet-display');
+  const winDisplay = document.getElementById('win-display');
+  const streakDisplay = document.getElementById('streak-display');
+  const multiplierDisplay = document.getElementById('multiplier-display');
+  const paylinesDisplay = document.getElementById('paylines-display');
+  const freeSpinsDisplay = document.getElementById('freespins-display');
+  const freeSpinsPanel = document.getElementById('freespins-panel');
+  const messageEl = document.getElementById('message-display');
+  const winBanner = document.getElementById('win-banner');
+  const winBannerText = document.getElementById('win-banner-text');
+  const sparkContainer = document.getElementById('spark-container');
+  const paylineHighlights = document.querySelectorAll('.payline-indicator');
+
+  const spinBtn = document.getElementById('btn-spin');
+  const bet1Btn = document.getElementById('btn-bet1');
+  const betMaxBtn = document.getElementById('btn-betmax');
+  const muteBtn = document.getElementById('btn-mute');
+  const resetBtn = document.getElementById('btn-reset');
+
+  let spinning = false;
+  let audioInitialized = false;
+
+  // ============================================================
+  // AUDIO INIT HELPER
+  // ============================================================
+  function ensureAudio() {
+    if (!audioInitialized) {
+      audio.init();
+      audioInitialized = true;
+    }
+  }
+
+  // ============================================================
+  // DISPLAY HELPERS
+  // ============================================================
+  function updateDisplays() {
+    // LED-style number display with leading zeros
+    const fmt = (n, digits = 6) => String(n).padStart(digits, '0');
+    creditDisplay.textContent = fmt(engine.credit);
+    betDisplay.textContent = fmt(engine.bet, 1);
+    winDisplay.textContent = fmt(engine.lastWin, 4);
+    streakDisplay.textContent = engine.winStreak;
+
+    const mult = engine.getStreakMultiplier();
+    multiplierDisplay.textContent = `×${mult.toFixed(1)}`;
+    multiplierDisplay.className = 'led-value';
+    if (mult >= 3) multiplierDisplay.classList.add('mult-x3');
+    else if (mult >= 2) multiplierDisplay.classList.add('mult-x2');
+    else if (mult >= 1.5) multiplierDisplay.classList.add('mult-x1-5');
+
+    const activeLines = engine.getActivePaylines();
+    paylinesDisplay.textContent = `LINES: ${activeLines}`;
+
+    // Free spin panel
+    if (engine.isFreeSpinMode) {
+      freeSpinsPanel.classList.add('active');
+      freeSpinsDisplay.textContent = engine.freeSpinsLeft;
+    } else {
+      freeSpinsPanel.classList.remove('active');
+    }
+
+    // Button states
+    spinBtn.disabled = spinning || !engine.canSpin();
+    bet1Btn.disabled = spinning || engine.isFreeSpinMode;
+    betMaxBtn.disabled = spinning || engine.isFreeSpinMode;
+
+    // Payline indicators
+    paylineHighlights.forEach((el, i) => {
+      el.classList.toggle('active', i < activeLines);
+    });
+  }
+
+  function setMessage(text, type = '') {
+    messageEl.textContent = text;
+    messageEl.className = 'message-display';
+    if (type) messageEl.classList.add('msg-' + type);
+  }
+
+  // ============================================================
+  // REEL RENDERING
+  // ============================================================
+  function renderReelWindow(reelIndex, symbols) {
+    const container = reelContainers[reelIndex];
+    const cells = container.querySelectorAll('.reel-cell');
+    symbols.forEach((sym, row) => {
+      const cell = cells[row];
+      cell.textContent = sym.label;
+      cell.className = 'reel-cell ' + (SYMBOL_COLOR[sym.key] || '');
+      // Center row gets highlight class
+      if (row === 1) cell.classList.add('center-row');
+    });
+  }
+
+  function renderInitialReels() {
+    const initSymbols = [
+      [{ key: 'CHERRY', label: '🍒' }, { key: 'SEVEN', label: '7' }, { key: 'BELL', label: '🔔' }],
+      [{ key: 'BELL', label: '🔔' }, { key: 'BAR', label: 'BAR' }, { key: 'LEMON', label: '🍋' }],
+      [{ key: 'LEMON', label: '🍋' }, { key: 'WATERMELON', label: '🍉' }, { key: 'GRAPE', label: '🍇' }],
+    ];
+    reelContainers.forEach((_, i) => renderReelWindow(i, initSymbols[i]));
+  }
+
+  // ============================================================
+  // REEL SPIN ANIMATION
+  // ============================================================
+  function getRandomSymbol() {
+    return SYMBOLS[Math.floor(Math.random() * SYMBOLS.length)];
+  }
+
+  function animateReel(reelIndex, finalSymbols, totalDuration) {
+    return new Promise(resolve => {
+      const container = reelContainers[reelIndex];
+      const cells = container.querySelectorAll('.reel-cell');
+      container.classList.add('spinning');
+
+      const frameInterval = 50; // ms between frames while spinning
+      let elapsed = 0;
+
+      const interval = setInterval(() => {
+        elapsed += frameInterval;
+        // Show random symbols while spinning
+        cells.forEach(cell => {
+          const sym = getRandomSymbol();
+          cell.textContent = sym.label;
+          cell.className = 'reel-cell spinning-frame ' + (SYMBOL_COLOR[sym.key] || '');
+          if (cell.classList.contains('center-row-marker')) cell.classList.add('center-row');
+        });
+
+        if (elapsed >= totalDuration) {
+          clearInterval(interval);
+          container.classList.remove('spinning');
+
+          // Set final symbols
+          finalSymbols.forEach((sym, row) => {
+            const cell = cells[row];
+            cell.textContent = sym.label;
+            cell.className = 'reel-cell stop-pop ' + (SYMBOL_COLOR[sym.key] || '');
+            if (row === 1) cell.classList.add('center-row');
+          });
+
+          // Play reel stop sound
+          audio.playReelStop(reelIndex);
+
+          // Remove pop animation class after it plays
+          setTimeout(() => {
+            cells.forEach(c => c.classList.remove('stop-pop'));
+          }, 300);
+
+          resolve();
+        }
+      }, frameInterval);
+    });
+  }
+
+  async function animateAllReels(reelWindows) {
+    const baseTime = 600;
+    const stagger = 300;
+
+    // Start all reels spinning with staggered stops
+    const promises = reelWindows.map((symbols, i) =>
+      animateReel(i, symbols, baseTime + stagger * i)
+    );
+    await Promise.all(promises);
+  }
+
+  // ============================================================
+  // WIN EFFECTS
+  // ============================================================
+  function highlightWinningPaylines(wins) {
+    // Remove all highlights first
+    reelContainers.forEach(c => {
+      c.querySelectorAll('.reel-cell').forEach(cell => cell.classList.remove('win-cell'));
+    });
+
+    wins.forEach(win => {
+      const payline = RULES.paylines[win.paylineIndex];
+      payline.forEach(([reelIdx, rowIdx]) => {
+        const cell = reelContainers[reelIdx].querySelectorAll('.reel-cell')[rowIdx];
+        cell.classList.add('win-cell');
+      });
+    });
+
+    // Remove after animation
+    setTimeout(() => {
+      reelContainers.forEach(c => {
+        c.querySelectorAll('.reel-cell').forEach(cell => cell.classList.remove('win-cell'));
+      });
+    }, 1500);
+  }
+
+  function spawnSparks(count, colorSet) {
+    sparkContainer.innerHTML = '';
+    for (let i = 0; i < count; i++) {
+      const spark = document.createElement('div');
+      spark.className = 'spark';
+      spark.style.left = `${10 + Math.random() * 80}%`;
+      spark.style.top = `${20 + Math.random() * 60}%`;
+      spark.style.setProperty('--dx', `${(Math.random() - 0.5) * 300}px`);
+      spark.style.setProperty('--dy', `${-50 - Math.random() * 200}px`);
+      spark.style.setProperty('--sc', colorSet[i % colorSet.length]);
+      spark.style.animationDelay = `${Math.random() * 200}ms`;
+      spark.style.animationDuration = `${500 + Math.random() * 500}ms`;
+      sparkContainer.appendChild(spark);
+    }
+    setTimeout(() => { sparkContainer.innerHTML = ''; }, 1200);
+  }
+
+  function showWinBanner(text, level) {
+    winBannerText.textContent = text;
+    winBanner.className = 'win-banner';
+    winBanner.classList.add('show', 'level-' + level);
+    setTimeout(() => {
+      winBanner.classList.remove('show', 'level-' + level);
+    }, level === 'jackpot' ? 3000 : 1800);
+  }
+
+  function triggerWinEffect(result) {
+    if (result.winLevel === 'jackpot') {
+      document.body.classList.add('jackpot-mode');
+      showWinBanner('JACKPOT!! 777', 'jackpot');
+      spawnSparks(60, ['#ffd700', '#ff4500', '#ff69b4', '#00bfff', '#adff2f']);
+      audio.playJackpot();
+      setTimeout(() => document.body.classList.remove('jackpot-mode'), 4000);
+    } else if (result.winLevel === 'bigwin') {
+      document.body.classList.add('bigwin-mode');
+      showWinBanner('BIG WIN!!', 'bigwin');
+      spawnSparks(40, ['#ffd700', '#ff6347', '#fff']);
+      audio.playBigWin();
+      setTimeout(() => document.body.classList.remove('bigwin-mode'), 2500);
+    } else if (result.winLevel === 'win') {
+      showWinBanner('WIN!', 'win');
+      spawnSparks(20, ['#ffd700', '#fff']);
+      audio.playWin();
+    } else if (result.winLevel === 'small') {
+      audio.playSmallWin();
+    } else {
+      audio.playLose();
+    }
+
+    if (result.freeSpinTriggered) {
+      setTimeout(() => {
+        showWinBanner('FREE SPIN!! 15回', 'freespin');
+        spawnSparks(50, ['#00bfff', '#7fff00', '#ffd700', '#ff69b4']);
+        audio.playFreeSpinTrigger();
+      }, result.winLevel === 'jackpot' ? 1500 : 500);
+    }
+
+    if (result.win > 0) {
+      highlightWinningPaylines(result.wins);
+    }
+  }
+
+  // ============================================================
+  // SPIN HANDLER
+  // ============================================================
+  async function onSpin() {
+    if (spinning) return;
+    ensureAudio();
+
+    // Free spin visual hint
+    if (engine.isFreeSpinMode) {
+      audio.playFreeSpin();
+    } else {
+      audio.playSpinStart();
+    }
+
+    const result = engine.spin();
+    if (!result.success) {
+      setMessage(result.error, 'error');
+      updateDisplays();
+      return;
+    }
+
+    spinning = true;
+    spinBtn.disabled = true;
+    setMessage('スピン中...', 'spinning');
+
+    // Animate reels
+    await animateAllReels(result.reelWindows);
+
+    spinning = false;
+
+    // Update displays
+    updateDisplays();
+
+    // Determine message and trigger effects
+    if (result.win > 0) {
+      const streakText = result.winStreak >= 2 ? ` [${result.winStreak}連勝 ×${result.multiplier.toFixed(1)}]` : '';
+      const winNames = result.wins.map(w => {
+        const sym = SYMBOLS.find(s => s.key === w.key);
+        return sym ? sym.name : w.key;
+      }).join(', ');
+      setMessage(`${winNames} +${result.win}枚${streakText}`, 'win');
+      triggerWinEffect(result);
+
+      if (result.winStreak >= 2 && result.winStreak % 1 === 0) {
+        audio.playStreakUp();
+      }
+    } else {
+      if (result.isFree) {
+        setMessage(`フリースピン残り ${result.freeSpinsLeft}回`, 'freespin');
+      } else {
+        setMessage('はずれ... もう1回！', 'lose');
+      }
+      triggerWinEffect(result); // plays lose sound
+    }
+
+    // Credit warn
+    if (engine.credit <= 5 && !engine.isFreeSpinMode) {
+      setMessage('クレジット不足！ リセットしてください。', 'error');
+    }
+  }
+
+  // ============================================================
+  // BUTTON HANDLERS
+  // ============================================================
+  spinBtn.addEventListener('click', () => {
+    ensureAudio();
+    audio.playButtonClick();
+    onSpin();
+  });
+
+  bet1Btn.addEventListener('click', () => {
+    ensureAudio();
+    if (spinning) return;
+    engine.setBet(1);
+    audio.playCoinInsert();
+    setMessage('1BET: 1ライン');
+    updateDisplays();
+  });
+
+  betMaxBtn.addEventListener('click', () => {
+    ensureAudio();
+    if (spinning) return;
+    engine.setMaxBet();
+    audio.playCoinInsert();
+    setMessage('MAX BET: 5ライン');
+    updateDisplays();
+  });
+
+  muteBtn.addEventListener('click', () => {
+    ensureAudio();
+    const nowEnabled = audio.toggleMute();
+    muteBtn.textContent = nowEnabled ? '🔊' : '🔇';
+    muteBtn.title = nowEnabled ? 'ミュート' : 'サウンドON';
+  });
+
+  resetBtn.addEventListener('click', () => {
+    ensureAudio();
+    if (spinning) return;
+    engine.reset();
+    renderInitialReels();
+    setMessage('リセット完了。SPIN を押してスタート！');
+    updateDisplays();
+  });
+
+  // Keyboard support
+  document.addEventListener('keydown', e => {
+    if (e.code === 'Space' && !spinBtn.disabled) {
+      e.preventDefault();
+      spinBtn.click();
+    }
+  });
+
+  // ============================================================
+  // STARTUP
+  // ============================================================
+  renderInitialReels();
+  updateDisplays();
+  setMessage('SPIN を押してスタート！ (Space キーでも可)');
+
+  // Mark center rows for reel animation
+  reelContainers.forEach(container => {
+    const cells = container.querySelectorAll('.reel-cell');
+    if (cells[1]) cells[1].classList.add('center-row-marker');
+  });
+});

--- a/src-v2/ui.js
+++ b/src-v2/ui.js
@@ -14,9 +14,14 @@ document.addEventListener('DOMContentLoaded', () => {
   const SYMBOLS = window.SlotSymbolsV2;
   const RULES = window.SlotRulesV2;
 
-  // Symbol display map
+  // Symbol display map (key → emoji/label)
   const SYMBOL_DISPLAY = {};
-  SYMBOLS.forEach(s => { SYMBOL_DISPLAY[s.key] = s.label; });
+  // Symbol name map (key → Japanese name)
+  const SYMBOL_NAME = {};
+  SYMBOLS.forEach(s => {
+    SYMBOL_DISPLAY[s.key] = s.label;
+    SYMBOL_NAME[s.key] = s.name;
+  });
 
   // Symbol color class map
   const SYMBOL_COLOR = {
@@ -160,11 +165,11 @@ document.addEventListener('DOMContentLoaded', () => {
       const interval = setInterval(() => {
         elapsed += frameInterval;
         // Show random symbols while spinning
-        cells.forEach(cell => {
+        cells.forEach((cell, row) => {
           const sym = getRandomSymbol();
           cell.textContent = sym.label;
-          cell.className = 'reel-cell spinning-frame ' + (SYMBOL_COLOR[sym.key] || '');
-          if (cell.classList.contains('center-row-marker')) cell.classList.add('center-row');
+          const centerClass = row === 1 ? 'center-row center-row-marker' : '';
+          cell.className = ['reel-cell', 'spinning-frame', centerClass, SYMBOL_COLOR[sym.key]].filter(Boolean).join(' ');
         });
 
         if (elapsed >= totalDuration) {
@@ -250,8 +255,10 @@ document.addEventListener('DOMContentLoaded', () => {
     winBannerText.textContent = text;
     winBanner.className = 'win-banner';
     winBanner.classList.add('show', 'level-' + level);
+    winBanner.removeAttribute('aria-hidden');
     setTimeout(() => {
       winBanner.classList.remove('show', 'level-' + level);
+      winBanner.setAttribute('aria-hidden', 'true');
     }, level === 'jackpot' ? 3000 : 1800);
   }
 
@@ -327,14 +334,13 @@ document.addEventListener('DOMContentLoaded', () => {
     // Determine message and trigger effects
     if (result.win > 0) {
       const streakText = result.winStreak >= 2 ? ` [${result.winStreak}連勝 ×${result.multiplier.toFixed(1)}]` : '';
-      const winNames = result.wins.map(w => {
-        const sym = SYMBOLS.find(s => s.key === w.key);
-        return sym ? sym.name : w.key;
-      }).join(', ');
+      const winNames = result.wins.map(w => SYMBOL_NAME[w.key] || w.key).join(', ');
       setMessage(`${winNames} +${result.win}枚${streakText}`, 'win');
       triggerWinEffect(result);
 
-      if (result.winStreak >= 2 && result.winStreak % 1 === 0) {
+      // Play streak-up sound only when the multiplier actually increases (at threshold boundaries)
+      const thresholdStreaks = RULES.streakThresholds.map(t => t.min);
+      if (thresholdStreaks.includes(result.winStreak)) {
         audio.playStreakUp();
       }
     } else {
@@ -384,6 +390,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const nowEnabled = audio.toggleMute();
     muteBtn.textContent = nowEnabled ? '🔊' : '🔇';
     muteBtn.title = nowEnabled ? 'ミュート' : 'サウンドON';
+    muteBtn.setAttribute('aria-label', nowEnabled ? 'ミュート' : 'サウンドON');
+    muteBtn.setAttribute('aria-pressed', String(!nowEnabled));
   });
 
   resetBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary

- **src-v2/engine.js**: 3リール×3行の独立エンジン。5ペイライン対応、777ジャックポット→15回フリースピントリガー、ウィンストリーク連鎖倍率（×1.5/×2/×3）、ベット1=1ライン/ベット2=3ライン/ベット3=5ライン
- **src-v2/audio.js**: Web Audio API完全実装。コイン投入・スピン開始・リール停止・小当たり・WIN・BIG WIN・JACKPOT・フリースピン・ストリークアップ各SFX
- **src-v2/ui.js**: リールスタガードアニメーション（600ms+300ms刻み）、勝利ペイライン点滅、スパーク爆発エフェクト、WIN/BIGWIN/JACKPOTバナーオーバーレイ
- **src-v2/styles.css**: 本格パチスロ筐体デザイン。LEDディスプレイ（グリーン発光）、マーキーライト追跡アニメーション、JACKPOT時全画面色相回転エフェクト、モバイル対応
- **src-v2/index.html**: 単体動作（CSS/JS相対パス参照）。セマンティックHTML、aria-label対応

## 当選役と配当

| 絵柄 | 配当 | 備考 |
|------|------|------|
| 7 7 7 | ×50 | **JACKPOT + FREE SPIN 15回** |
| BAR×3 | ×20 | |
| スイカ×3 | ×10 | |
| ベル×3 | ×5 | |
| ブドウ×3 / レモン×3 | ×3 | |
| チェリー×3 | ×2 | |
| チェリー 1枚以上(センター) | ×2 | |

## Test plan

- [ ] `src-v2/index.html` をブラウザで直接開き、単体動作を確認
- [ ] SPIN ボタン / Space キーでスピン開始
- [ ] 1BET → 1ライン、MAX BET → 5ライン のペイライン表示切り替え
- [ ] 当選時にスパークエフェクトとWINバナーが表示される
- [ ] 777揃い時にフリースピンパネルが表示され15回カウントダウン
- [ ] 連勝でストリーク倍率が×1.5→×2→×3に上昇
- [ ] RESET でクレジット100枚に戻る
- [ ] サウンドON/OFF（🔊ボタン）が機能する
- [ ] モバイル幅（400px以下）でレイアウト崩れがない

🤖 Generated with [Claude Code](https://claude.com/claude-code)