### PR TITLE
fix: GitHub PagesでVOICEVOX音声を有効化（Cloud Run経由）

### DIFF
--- a/src/scripts/ui.js
+++ b/src/scripts/ui.js
@@ -43,7 +43,7 @@ function getDefaultVoicevoxUrl() {
   }
   if (isGitHubPages()) {
     const saved = localStorage.getItem("voiceApi");
-    return saved || null;
+    return saved || "https://voicevox-proxy-932581541278.asia-northeast1.run.app/voicevox";
   }
   return "/voicevox";
 }


### PR DESCRIPTION
Cloud Run上にVOICEVOXエンジン+CORSプロキシをデプロイし、GitHub Pagesから自動接続するよう設定。